### PR TITLE
fix(checkpoint): fix slower nodes are prone to viewchange

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Rican7/retry v0.3.1
-	github.com/axiomesh/axiom-bft v0.0.3-0.20231013093932-09b0847b240c
+	github.com/axiomesh/axiom-bft v0.0.3-0.20231016024042-d593ac6015a6
 	github.com/axiomesh/axiom-kit v0.0.3-0.20231013074219-561160e44d38
 	github.com/axiomesh/axiom-p2p v0.0.3-0.20231011042444-dbec9ddc0bae
 	github.com/axiomesh/eth-kit v0.0.3-0.20231009042227-264fda908a53

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/axiomesh/axiom-bft v0.0.3-0.20231013093932-09b0847b240c h1:gcXM6fQTl4OgvB3os0gsGRNEZX0PhJNZBDM70stVshU=
-github.com/axiomesh/axiom-bft v0.0.3-0.20231013093932-09b0847b240c/go.mod h1:26oKvpFCzD4D5M7Kv7zivA6QetKBQkUyRvR7jz9bbbg=
+github.com/axiomesh/axiom-bft v0.0.3-0.20231016024042-d593ac6015a6 h1:LeA/bTQTn8qNzWzE6vSw4iR9qWAyS13pJXFFJJ5Os28=
+github.com/axiomesh/axiom-bft v0.0.3-0.20231016024042-d593ac6015a6/go.mod h1:26oKvpFCzD4D5M7Kv7zivA6QetKBQkUyRvR7jz9bbbg=
 github.com/axiomesh/axiom-kit v0.0.3-0.20231013074219-561160e44d38 h1:d6jCcksiNcZsQPMwlRjNDQXamMspMhzedHz0zvmTlBI=
 github.com/axiomesh/axiom-kit v0.0.3-0.20231013074219-561160e44d38/go.mod h1:XuDEVIAtMfrAHhgEnAE9zEnlH/5ehyZwLVZRm4/RzDU=
 github.com/axiomesh/axiom-p2p v0.0.3-0.20231011042444-dbec9ddc0bae h1:Hr0V4rjSILngefEmowT7PceW09+2Qx7eL6q6coEr0qQ=

--- a/internal/consensus/rbft/config.go
+++ b/internal/consensus/rbft/config.go
@@ -38,6 +38,7 @@ func defaultRbftConfig() rbft.Config {
 		Logger:                  nil,
 		NoTxBatchTimeout:        0,
 		CheckPoolRemoveTimeout:  30 * time.Minute,
+		MinimumNumberOfBatchesToRetainAfterCheckpoint: 10,
 	}
 }
 
@@ -94,6 +95,9 @@ func generateRbftConfig(config *common.Config) (rbft.Config, txpool.Config) {
 		defaultConfig.MetricsProv = &prometheus.Provider{
 			Name: "rbft",
 		}
+	}
+	if readConfig.Rbft.MinimumNumberOfBatchesToRetainAfterCheckpoint > 0 {
+		defaultConfig.MinimumNumberOfBatchesToRetainAfterCheckpoint = readConfig.Rbft.MinimumNumberOfBatchesToRetainAfterCheckpoint
 	}
 	fn := func(addr string) uint64 {
 		return config.GetAccountNonce(types.NewAddressByStr(addr))

--- a/pkg/repo/chainnet.go
+++ b/pkg/repo/chainnet.go
@@ -224,6 +224,7 @@ func AriesConsensusConfig() *ConsensusConfig {
 			EnableMultiPipes: false,
 			EnableMetrics:    true,
 			CheckInterval:    Duration(3 * time.Minute),
+			MinimumNumberOfBatchesToRetainAfterCheckpoint: 10,
 			Timeout: RBFTTimeout{
 				SyncState:        Duration(3 * time.Second),
 				SyncInterval:     Duration(1 * time.Minute),

--- a/pkg/repo/consensus.go
+++ b/pkg/repo/consensus.go
@@ -48,10 +48,11 @@ type TxCache struct {
 }
 
 type RBFT struct {
-	EnableMultiPipes bool        `mapstructure:"enable_multi_pipes" toml:"enable_multi_pipes"`
-	EnableMetrics    bool        `mapstructure:"enable_metrics" toml:"enable_metrics"`
-	CheckInterval    Duration    `mapstructure:"check_interval" toml:"check_interval"`
-	Timeout          RBFTTimeout `mapstructure:"timeout" toml:"timeout"`
+	EnableMultiPipes                              bool        `mapstructure:"enable_multi_pipes" toml:"enable_multi_pipes"`
+	EnableMetrics                                 bool        `mapstructure:"enable_metrics" toml:"enable_metrics"`
+	CheckInterval                                 Duration    `mapstructure:"check_interval" toml:"check_interval"`
+	MinimumNumberOfBatchesToRetainAfterCheckpoint uint64      `mapstructure:"minimum_number_of_batches_to_retain_after_checkpoint" toml:"minimum_number_of_batches_to_retain_after_checkpoint"`
+	Timeout                                       RBFTTimeout `mapstructure:"timeout" toml:"timeout"`
 }
 
 type RBFTTimeout struct {
@@ -105,6 +106,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 			EnableMultiPipes: false,
 			EnableMetrics:    true,
 			CheckInterval:    Duration(3 * time.Minute),
+			MinimumNumberOfBatchesToRetainAfterCheckpoint: 10,
 			Timeout: RBFTTimeout{
 				SyncState:        Duration(3 * time.Second),
 				SyncInterval:     Duration(1 * time.Minute),


### PR DESCRIPTION
when checkpoint is 1, the primary node cleans transactions too quickly, which can easily cause the slower replica node to lose the old batch and viewchange