### PR TITLE
fix: add gas for kyc service, check kyc proposal

### DIFF
--- a/api/jsonrpc/namespaces/eth/transaction_api.go
+++ b/api/jsonrpc/namespaces/eth/transaction_api.go
@@ -244,7 +244,7 @@ func (api *TransactionAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, 
 
 	// kyc verify switch
 	if api.rep.Config.Access.KycVerification == repo.EnableKycVerify {
-		success, err := access.Verify(api.api.Broker().GetViewStateLedger().NewView(), tx.GetFrom())
+		success, err := access.Verify(api.api.Broker().GetViewStateLedger().NewView(), tx.GetFrom().String())
 		if err != nil || !success {
 			return [32]byte{}, err
 		}

--- a/internal/executor/system/access/kyc_verification.go
+++ b/internal/executor/system/access/kyc_verification.go
@@ -24,18 +24,17 @@ import (
 )
 
 const (
-	SubmitMethod          = "Submit"
-	RemoveMethod          = "Remove"
-	KycSubmitGas   uint64 = 30000
-	KycRemoveGas   uint64 = 30000
-	KycInfoKey            = "kycinfo"
-	KycServicesKey        = "kycservices"
+	SubmitMethod   = "Submit"
+	RemoveMethod   = "Remove"
+	KycInfoKey     = "kycinfo"
+	KycServicesKey = "kycservices"
 )
 
 var _ common.SystemContract = (*KycVerification)(nil)
 
 var (
-	ErrCheckSubmitInfo = errors.New("check submit info fail")
+	ErrCheckSubmitInfo = errors.New("check submit kyc info fail")
+	ErrCheckRemoveInfo = errors.New("check remove kyc info fail")
 )
 
 type KycFlag uint8
@@ -48,13 +47,17 @@ const (
 )
 
 const (
+	LongTermValidity int64 = -1
+)
+
+const (
 	NotVerified KycFlag = iota
 	Verified
 )
 
 type KycInfo struct {
-	User    types.Address
-	KycAddr types.Address
+	User    string
+	KycAddr string
 	KycFlag KycFlag
 	Expires int64
 }
@@ -64,19 +67,19 @@ type BaseExtraArgs struct {
 }
 
 type SubmitArgs struct {
-	KycInfos []*KycInfo
+	KycInfos []KycInfo
 }
 
 type RemoveArgs struct {
-	Addresses []*types.Address
+	Addresses []string
 }
 
 type KycService struct {
-	KycAddr types.Address
+	KycAddr string
 }
 
 type KycServiceArgs struct {
-	Services []*KycService
+	Services []KycService
 }
 
 var method2Sig = map[string]string{
@@ -141,21 +144,12 @@ func (c *KycVerification) Reset(stateLedger ledger.StateLedger) {
 }
 
 func (c *KycVerification) EstimateGas(callArgs *types.CallArgs) (uint64, error) {
-	args, err := c.getArgs(&vm.Message{Data: *callArgs.Data})
+	_, err := c.getArgs(&vm.Message{Data: *callArgs.Data})
 	if err != nil {
 		return 0, err
 	}
-
-	var gas uint64
-	switch args.(type) {
-	case *SubmitArgs:
-		gas = KycSubmitGas
-	case *RemoveArgs:
-		gas = KycRemoveGas
-	default:
-		return 0, fmt.Errorf("ACCESS ERROR: unknown access args")
-	}
-	return gas, nil
+	dynamicGas := common.CalculateDynamicGas(*callArgs.Data)
+	return dynamicGas, nil
 }
 
 func (c *KycVerification) CheckAndUpdateState(lastHeight uint64, stateLedger ledger.StateLedger) {}
@@ -174,7 +168,11 @@ func (c *KycVerification) Run(msg *vm.Message) (*vm.ExecutionResult, error) {
 	case *RemoveArgs:
 		result, err = c.Remove(&msg.From, v)
 	default:
-		return nil, fmt.Errorf("ACCESS ERROR: Run: unknown access args")
+		return nil, fmt.Errorf("access error: Run: unknown access args")
+	}
+	usedGas := common.CalculateDynamicGas(msg.Data)
+	if result != nil {
+		result.UsedGas = usedGas
 	}
 	return result, err
 }
@@ -195,7 +193,7 @@ func (c *KycVerification) getArgs(msg *vm.Message) (any, error) {
 			return nil, err
 		}
 		submitArgs := &SubmitArgs{}
-		if err = json.Unmarshal(args.Extra, &submitArgs); err != nil {
+		if err = json.Unmarshal(args.Extra, submitArgs); err != nil {
 			return nil, err
 		}
 		return submitArgs, nil
@@ -205,31 +203,31 @@ func (c *KycVerification) getArgs(msg *vm.Message) (any, error) {
 			return nil, err
 		}
 		removeArgs := &RemoveArgs{}
-		if err = json.Unmarshal(args.Extra, &removeArgs); err != nil {
+		if err = json.Unmarshal(args.Extra, removeArgs); err != nil {
 			return nil, err
 		}
 		return removeArgs, nil
 	default:
-		return nil, fmt.Errorf("ACCESS ERROR: getArgs: wrong method name")
+		return nil, fmt.Errorf("access error: getArgs: wrong method name")
 	}
 }
 
 // ParseArgs parse the arguments to specified interface by method name
 func (c *KycVerification) ParseArgs(msg *vm.Message, methodName string, ret any) error {
 	if len(msg.Data) < 4 {
-		return fmt.Errorf("ACCESS ERROR: ParseArgs: msg data length is not improperly formatted: %q - Bytes: %+v", msg.Data, msg.Data)
+		return fmt.Errorf("access error: ParseArgs: msg data length is not improperly formatted: %q - Bytes: %+v", msg.Data, msg.Data)
 	}
 	// discard method id
 	data := msg.Data[4:]
 	var args abi.Arguments
 	if method, ok := c.gabi.Methods[methodName]; ok {
 		if len(data)%32 != 0 {
-			return fmt.Errorf("ACCESS ERROR: ParseArgs: improperly formatted output: %q - Bytes: %+v", data, data)
+			return fmt.Errorf("access error: ParseArgs: improperly formatted output: %q - Bytes: %+v", data, data)
 		}
 		args = method.Inputs
 	}
 	if args == nil {
-		return fmt.Errorf("ACCESS ERROR: ParseArgs: could not locate named method: %s", methodName)
+		return fmt.Errorf("access error: ParseArgs: could not locate named method: %s", methodName)
 	}
 	unpacked, err := args.Unpack(data)
 	if err != nil {
@@ -241,18 +239,18 @@ func (c *KycVerification) ParseArgs(msg *vm.Message, methodName string, ret any)
 func (c *KycVerification) getMethodName(data []byte) (string, error) {
 	for methodName, methodSig := range c.method2Sig {
 		id := methodSig[:4]
-		c.logger.Debugf("ACCESS ERROR: getMethodName: method is: %v, get method id: %v", id, data[:4])
+		c.logger.Debugf("access error: getMethodName: method is: %v, get method id: %v", id, data[:4])
 		if bytes.Equal(id, data[:4]) {
 			return methodName, nil
 		}
 	}
-	return "", fmt.Errorf("ACCESS ERROR: getMethodName")
+	return "", fmt.Errorf("access error: getMethodName")
 }
 
 func (c *KycVerification) Submit(from *ethcommon.Address, args *SubmitArgs) (*vm.ExecutionResult, error) {
 	success := CheckInServices(c.account, from.String())
 	if !success {
-		return nil, fmt.Errorf("ACCESS ERROR: Submit: fail by checking kyc services")
+		return nil, fmt.Errorf("access error: Submit: fail by checking kyc services")
 	}
 	for _, info := range args.KycInfos {
 		err := c.checkSubmitInfo(from, info)
@@ -270,19 +268,21 @@ func (c *KycVerification) Submit(from *ethcommon.Address, args *SubmitArgs) (*vm
 		return nil, err
 	}
 	return &vm.ExecutionResult{
-		UsedGas:    KycSubmitGas,
 		ReturnData: b,
-		Err:        nil,
 	}, nil
 }
 
 func (c *KycVerification) Remove(from *ethcommon.Address, args *RemoveArgs) (*vm.ExecutionResult, error) {
 	success := CheckInServices(c.account, from.String())
 	if !success {
-		return nil, fmt.Errorf("ACCESS ERROR: Remove: check kyc service fail")
+		return nil, fmt.Errorf("access error: Remove: check kyc service fail")
 	}
 	for _, addr := range args.Addresses {
-		err := c.removeKycInfo(addr.String())
+		err := c.checkRemoveInfo(addr)
+		if err != nil {
+			return nil, err
+		}
+		err = c.removeKycInfo(addr)
 		if err != nil {
 			return nil, err
 		}
@@ -292,38 +292,52 @@ func (c *KycVerification) Remove(from *ethcommon.Address, args *RemoveArgs) (*vm
 		return nil, err
 	}
 	return &vm.ExecutionResult{
-		UsedGas:    KycRemoveGas,
 		ReturnData: b,
-		Err:        nil,
 	}, nil
 }
 
-func Verify(lg ledger.StateLedger, needApprove *types.Address) (bool, error) {
+func Verify(lg ledger.StateLedger, needApprove string) (bool, error) {
+	logger := loggers.Logger(loggers.Access)
 	account := lg.GetOrCreateAccount(types.NewAddressByStr(common.KycVerifyContractAddr))
-	state, bytes := account.GetState([]byte(KycInfoKey + needApprove.String()))
+	state, bytes := account.GetState([]byte(KycInfoKey + needApprove))
 	if !state {
-		return false, fmt.Errorf("ACCESS ERROR: Verify: fail by GetState")
+		logger.Debugf("verify user addr fail by GetState, addr is %s", needApprove)
+		return false, fmt.Errorf("access error")
 	}
 	info := &KycInfo{}
 	if err := json.Unmarshal(bytes, &info); err != nil {
-		return false, fmt.Errorf("ACCESS ERROR: Verify: fail by json.Unmarshal")
+		logger.Debugf("verify fail by json.Unmarshal, addr is %s", needApprove)
+		return false, fmt.Errorf("access error")
 	}
 	// long-term validity
-	if info.Expires == -1 && info.KycFlag == 1 {
+	if info.Expires == LongTermValidity && info.KycFlag == Verified {
 		return true, nil
 	}
-	if time.Now().Unix() > info.Expires || info.KycFlag != 1 {
-		return false, fmt.Errorf("ACCESS ERROR: Verify: fail by checking kyc info")
+	if time.Now().Unix() > info.Expires || info.KycFlag != Verified {
+		logger.Debugf("verify fail by checking kyc info, addr is %s", needApprove)
+		return false, fmt.Errorf("access error")
 	}
 	return true, nil
 }
 
-func (c *KycVerification) saveKycInfo(info *KycInfo) error {
+func (c *KycVerification) saveKycInfo(info KycInfo) error {
 	b, err := json.Marshal(info)
 	if err != nil {
 		return err
 	}
-	c.account.SetState([]byte(KycInfoKey+info.User.String()), b)
+	c.account.SetState([]byte(KycInfoKey+info.User), b)
+	return nil
+}
+
+func (c *KycVerification) getKycInfo(addr string) *KycInfo {
+	state, i := c.account.GetState([]byte(KycInfoKey + addr))
+	if state {
+		res := &KycInfo{}
+		err := json.Unmarshal(i, res)
+		if err != nil {
+			return res
+		}
+	}
 	return nil
 }
 
@@ -351,48 +365,58 @@ func CheckInServices(account ledger.IAccount, addr string) bool {
 	if !isExist {
 		return false
 	}
-	var Services []*KycService
+	var Services []KycService
 	if err := json.Unmarshal(data, &Services); err != nil {
 		return false
 	}
 	if len(Services) == 0 {
 		return false
 	}
-	isExist = common.IsInSlice[string](addr, lo.Map[*KycService, string](Services, func(item *KycService, index int) string {
-		return item.KycAddr.String()
+	isExist = common.IsInSlice[string](addr, lo.Map[KycService, string](Services, func(item KycService, index int) string {
+		return item.KycAddr
 	}))
 	return isExist
 }
 
-func AddAndRemoveKycService(lg ledger.StateLedger, modifyType ModifyType, inputServices []*KycService) error {
+func AddAndRemoveKycService(lg ledger.StateLedger, modifyType ModifyType, inputServices []KycService) error {
 	existServices, err := GetKycServices(lg)
 	if err != nil {
 		return err
 	}
-	if modifyType == AddKycService {
+	switch modifyType {
+	case AddKycService:
 		existServices = append(existServices, inputServices...)
-		addrToServiceMap := lo.Associate(existServices, func(service *KycService) (ethcommon.Address, *KycService) {
-			return service.KycAddr.ETHAddress(), service
+		addrToServiceMap := lo.Associate(existServices, func(service KycService) (string, KycService) {
+			return service.KycAddr, service
 		})
-		existServices = lo.MapToSlice(addrToServiceMap, func(key ethcommon.Address, value *KycService) *KycService {
+		existServices = lo.MapToSlice(addrToServiceMap, func(key string, value KycService) KycService {
 			return value
 		})
-	} else if modifyType == RemoveKycService && len(existServices) > 0 {
-		addrToServiceMap := lo.Associate(existServices, func(service *KycService) (ethcommon.Address, *KycService) {
-			return service.KycAddr.ETHAddress(), service
-		})
-		filteredMembers := lo.Reject(inputServices, func(service *KycService, _ int) bool {
-			_, exists := addrToServiceMap[service.KycAddr.ETHAddress()]
-			return exists
-		})
-		existServices = filteredMembers
-	} else if modifyType == RemoveKycService && len(existServices) <= 0 {
-		return fmt.Errorf("ACCESS ERROR: remove kyc services from an empty list")
+		return SetKycService(lg, existServices)
+	case RemoveKycService:
+		if len(existServices) > 0 {
+			addrToServiceMap := lo.Associate(existServices, func(service KycService) (string, KycService) {
+				return service.KycAddr, service
+			})
+			filteredMembers := lo.Reject(inputServices, func(service KycService, _ int) bool {
+				_, exists := addrToServiceMap[service.KycAddr]
+				return exists
+			})
+			existServices = filteredMembers
+			return SetKycService(lg, existServices)
+		} else {
+			return fmt.Errorf("access error: remove kyc services from an empty list")
+		}
+	default:
+		return fmt.Errorf("access error: wrong submit type")
 	}
-	return SetKycService(lg, existServices)
 }
 
-func SetKycService(lg ledger.StateLedger, services []*KycService) error {
+func SetKycService(lg ledger.StateLedger, services []KycService) error {
+	// Sort list based on the KycAddr
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].KycAddr < services[j].KycAddr
+	})
 	cb, err := json.Marshal(services)
 	if err != nil {
 		return err
@@ -401,9 +425,9 @@ func SetKycService(lg ledger.StateLedger, services []*KycService) error {
 	return nil
 }
 
-func GetKycServices(lg ledger.StateLedger) ([]*KycService, error) {
+func GetKycServices(lg ledger.StateLedger) ([]KycService, error) {
 	success, data := lg.GetOrCreateAccount(types.NewAddressByStr(common.KycVerifyContractAddr)).GetState([]byte(KycServicesKey))
-	var services []*KycService
+	var services []KycService
 	if success {
 		if err := json.Unmarshal(data, &services); err != nil {
 			return nil, err
@@ -431,12 +455,11 @@ func InitKycServicesAndKycInfos(lg ledger.StateLedger, initVerifiedUsers []strin
 	sort.Strings(allAddresses)
 	// set init verified users
 	for _, addrStr := range allAddresses {
-		addr := types.NewAddressByStr(addrStr)
 		info := &KycInfo{
-			User:    *addr,
-			KycAddr: *addr,
+			User:    addrStr,
+			KycAddr: addrStr,
 			KycFlag: Verified,
-			Expires: -1,
+			Expires: LongTermValidity,
 		}
 		b, err := json.Marshal(info)
 		if err != nil {
@@ -445,20 +468,24 @@ func InitKycServicesAndKycInfos(lg ledger.StateLedger, initVerifiedUsers []strin
 		account.SetState([]byte(KycInfoKey+addrStr), b)
 	}
 	// set init kyc services addresses
-	var kycServices []*KycService
+	var kycServices []KycService
 	for _, addrStr := range initKycServices {
-		addr := types.NewAddressByStr(addrStr)
-		service := &KycService{
-			KycAddr: *addr,
+		service := KycService{
+			KycAddr: addrStr,
 		}
 		kycServices = append(kycServices, service)
 	}
+	// Sort list based on the KycAddr
+	sort.Slice(kycServices, func(i, j int) bool {
+		return kycServices[i].KycAddr < kycServices[j].KycAddr
+	})
 	kycServicesBytes, err := json.Marshal(kycServices)
 	if err != nil {
 		return err
 	}
 	account.SetState([]byte(KycServicesKey), kycServicesBytes)
-
+	logger := loggers.Logger(loggers.Access)
+	logger.Debugf("finish init kyc services and kyc infos")
 	return nil
 }
 
@@ -474,14 +501,43 @@ func (c *KycVerification) SaveLog(stateLedger ledger.StateLedger, currentLog *co
 	}
 }
 
-func (c *KycVerification) checkSubmitInfo(from *ethcommon.Address, info *KycInfo) error {
-	if info == nil || info.KycAddr.String() != from.String() {
-		c.logger.Debugf("ACCESS ERROR: info == nil or kyc addr is not same")
+func (c *KycVerification) checkSubmitInfo(from *ethcommon.Address, info KycInfo) error {
+	// check user addr
+	if addr := types.NewAddressByStr(info.User); addr.ETHAddress().String() != info.User {
+		c.logger.Debugf("access error: info user addr is invalid")
 		return ErrCheckSubmitInfo
 	}
-	if time.Now().Unix() > info.Expires && info.Expires != -1 {
-		c.logger.Debugf("ACCESS ERROR: kyc info is expired")
+	// check kyc service addr
+	if info.KycAddr != from.String() {
+		c.logger.Debugf("access error: kyc addr is not same")
 		return ErrCheckSubmitInfo
+	}
+	// check time
+	if time.Now().Unix() > info.Expires {
+		c.logger.Debugf("access error: kyc info is expired")
+		return ErrCheckSubmitInfo
+	}
+	// check kycflag
+	if info.KycFlag != Verified {
+		c.logger.Debugf("access error: kyc info is not verified")
+		return ErrCheckSubmitInfo
+	}
+	// check admins
+	kycInfo := c.getKycInfo(info.User)
+	if kycInfo != nil && kycInfo.Expires == -1 && kycInfo.KycFlag == Verified {
+		c.logger.Debugf("access error: try to modify system user's kyc info")
+		return ErrCheckSubmitInfo
+	}
+
+	return nil
+}
+
+func (c *KycVerification) checkRemoveInfo(addr string) error {
+	// check admin
+	info := c.getKycInfo(addr)
+	if info != nil && info.KycFlag == Verified && info.Expires == LongTermValidity {
+		c.logger.Debugf("access error: try to remove system user's kyc info")
+		return ErrCheckRemoveInfo
 	}
 	return nil
 }

--- a/internal/executor/system/access/kyc_verification_test.go
+++ b/internal/executor/system/access/kyc_verification_test.go
@@ -65,25 +65,34 @@ func TestKycVerification_RunForSubmit(t *testing.T) {
 		{
 			Caller: admin1,
 			Data: generateRunData(t, SubmitMethod, &SubmitArgs{
-				KycInfos: []*KycInfo{
+				KycInfos: []KycInfo{
 					{
-						User:    *types.NewAddressByStr(admin3),
-						KycAddr: *types.NewAddressByStr(admin1),
+						User:    admin3,
+						KycAddr: admin1,
 						KycFlag: Verified,
-						Expires: -1,
+						Expires: time.Now().Unix() + 10000,
 					},
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycSubmitGas,
-				Err:     nil,
-				ReturnData: generateReturnData(t, &SubmitArgs{
-					KycInfos: []*KycInfo{
+				UsedGas: common.CalculateDynamicGas(generateRunData(t, SubmitMethod, &SubmitArgs{
+					KycInfos: []KycInfo{
 						{
-							User:    *types.NewAddressByStr(admin3),
-							KycAddr: *types.NewAddressByStr(admin1),
+							User:    admin3,
+							KycAddr: admin1,
 							KycFlag: Verified,
-							Expires: -1,
+							Expires: time.Now().Unix() + 10000,
+						},
+					},
+				})),
+				Err: nil,
+				ReturnData: generateReturnData(t, &SubmitArgs{
+					KycInfos: []KycInfo{
+						{
+							User:    admin3,
+							KycAddr: admin1,
+							KycFlag: Verified,
+							Expires: time.Now().Unix() + 10000,
 						},
 					},
 				}),
@@ -94,11 +103,11 @@ func TestKycVerification_RunForSubmit(t *testing.T) {
 			Caller: admin1,
 			Data:   []byte{0, 1, 2, 3},
 			Expected: vm.ExecutionResult{
-				UsedGas:    KycSubmitGas,
-				Err:        fmt.Errorf("ACCESS ERROR: getMethodName"),
+				UsedGas:    0,
+				Err:        fmt.Errorf("access error: getMethodName"),
 				ReturnData: nil,
 			},
-			Err: fmt.Errorf("ACCESS ERROR: getMethodName"),
+			Err: fmt.Errorf("access error: getMethodName"),
 		},
 	}
 
@@ -125,14 +134,14 @@ func TestKycVerification_RunForSubmit(t *testing.T) {
 			assert.Equal(t, *expectedArgs, *actualArgs)
 
 			for _, info := range expectedArgs.KycInfos {
-				state, bytes := account.GetState([]byte(KycInfoKey + info.User.ETHAddress().String()))
+				state, bytes := account.GetState([]byte(KycInfoKey + info.User))
 				assert.True(t, state)
 				dbInfo := &KycInfo{}
 				err = json.Unmarshal(bytes, dbInfo)
 				assert.Nil(t, err)
-				assert.Equal(t, info, dbInfo)
+				assert.Equal(t, info, *dbInfo)
 
-				verify, err := Verify(stateLedger, &info.User)
+				verify, err := Verify(stateLedger, info.User)
 				assert.Nil(t, err)
 				assert.Equal(t, true, verify)
 			}
@@ -164,12 +173,12 @@ func TestKycVerification_RunForRemove(t *testing.T) {
 
 	address := types.NewAddressByStr(admin1).ETHAddress()
 	cm.Reset(stateLedger)
-	_, err = cm.Submit(&address, &SubmitArgs{KycInfos: []*KycInfo{
+	_, err = cm.Submit(&address, &SubmitArgs{KycInfos: []KycInfo{
 		{
-			User:    *types.NewAddressByStr(admin3),
-			KycAddr: *types.NewAddressByStr(admin1),
+			User:    admin3,
+			KycAddr: admin1,
 			KycFlag: Verified,
-			Expires: -1,
+			Expires: time.Now().Unix() + 10000,
 		},
 	}})
 	assert.Nil(t, err)
@@ -183,16 +192,20 @@ func TestKycVerification_RunForRemove(t *testing.T) {
 		{
 			Caller: admin1,
 			Data: generateRunData(t, RemoveMethod, &RemoveArgs{
-				Addresses: []*types.Address{
-					types.NewAddressByStr(admin3),
+				Addresses: []string{
+					admin3,
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycRemoveGas,
-				Err:     nil,
+				UsedGas: common.CalculateDynamicGas(generateRunData(t, RemoveMethod, &RemoveArgs{
+					Addresses: []string{
+						admin3,
+					},
+				})),
+				Err: nil,
 				ReturnData: generateReturnData(t, &RemoveArgs{
-					Addresses: []*types.Address{
-						types.NewAddressByStr(admin3),
+					Addresses: []string{
+						admin3,
 					},
 				}),
 			},
@@ -223,7 +236,7 @@ func TestKycVerification_RunForRemove(t *testing.T) {
 			assert.Equal(t, *expectedArgs, *actualArgs)
 
 			for _, addr := range expectedArgs.Addresses {
-				state, bytes := account.GetState([]byte(KycInfoKey + addr.ETHAddress().String()))
+				state, bytes := account.GetState([]byte(KycInfoKey + addr))
 				if state {
 					dbInfo := &KycInfo{}
 					err := json.Unmarshal(bytes, dbInfo)
@@ -250,10 +263,10 @@ func TestEstimateGas(t *testing.T) {
 	to := types.NewAddressByStr(common.KycVerifyContractAddr).ETHAddress()
 
 	data := hexutil.Bytes(generateRunData(t, SubmitMethod, &SubmitArgs{
-		KycInfos: []*KycInfo{
+		KycInfos: []KycInfo{
 			{
-				User:    *types.NewAddressByStr(admin1),
-				KycAddr: *types.NewAddressByStr(admin1),
+				User:    admin1,
+				KycAddr: admin1,
 				KycFlag: Verified,
 				Expires: -1,
 			},
@@ -265,16 +278,16 @@ func TestEstimateGas(t *testing.T) {
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, KycSubmitGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(data), gas)
 
-	data = hexutil.Bytes(generateRunData(t, RemoveMethod, &RemoveArgs{Addresses: []*types.Address{types.NewAddressByStr(admin1)}}))
+	data = hexutil.Bytes(generateRunData(t, RemoveMethod, &RemoveArgs{Addresses: []string{admin1}}))
 	gas, err = cm.EstimateGas(&types.CallArgs{
 		From: &from,
 		To:   &to,
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, KycRemoveGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(data), gas)
 
 	// test error args
 	data = hexutil.Bytes([]byte{0, 1, 2, 3})
@@ -322,7 +335,7 @@ func TestKycVerification_ParseErrorArgs(t *testing.T) {
 		{
 			method:   "Submit",
 			data:     []byte{1},
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: msg data length is not improperly formatted: %q - Bytes: %+v", []byte{1}, []byte{1}).Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: msg data length is not improperly formatted: %q - Bytes: %+v", []byte{1}, []byte{1}).Error(),
 		},
 		{
 			method:   "Submit",
@@ -332,17 +345,17 @@ func TestKycVerification_ParseErrorArgs(t *testing.T) {
 		{
 			method:   "Submit",
 			data:     []byte{1, 2, 3, 4, 5, 6, 7, 8},
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{5, 6, 7, 8}, []byte{5, 6, 7, 8}).Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{5, 6, 7, 8}, []byte{5, 6, 7, 8}).Error(),
 		},
 		{
 			method:   "test method",
 			data:     []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36},
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: could not locate named method: %s", "test method").Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: could not locate named method: %s", "test method").Error(),
 		},
 		{
 			method:   "test method",
 			data:     truedata,
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: could not locate named method: %s", "test method").Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: could not locate named method: %s", "test method").Error(),
 		},
 	}
 
@@ -359,10 +372,10 @@ func TestGetArgsForSubmit(t *testing.T) {
 	cm := NewKycVerification(&common.SystemContractConfig{
 		Logger: logrus.New(),
 	})
-	submitArgs := &SubmitArgs{KycInfos: []*KycInfo{
+	submitArgs := &SubmitArgs{KycInfos: []KycInfo{
 		{
-			User:    *types.NewAddressByStr(admin3),
-			KycAddr: *types.NewAddressByStr(admin1),
+			User:    admin3,
+			KycAddr: admin1,
 			KycFlag: 1,
 			Expires: -1,
 		},
@@ -379,16 +392,16 @@ func TestGetArgsForSubmit(t *testing.T) {
 
 	actualArgs, ok := arg.(*SubmitArgs)
 	assert.True(t, ok)
-	assert.Equal(t, submitArgs.KycInfos[0].User.String(), actualArgs.KycInfos[0].User.String())
+	assert.Equal(t, submitArgs.KycInfos[0].User, actualArgs.KycInfos[0].User)
 }
 
 func TestGetArgsForRemove(t *testing.T) {
 	cm := NewKycVerification(&common.SystemContractConfig{
 		Logger: logrus.New(),
 	})
-	removeArgs := &RemoveArgs{Addresses: []*types.Address{
-		types.NewAddressByStr(admin1),
-		types.NewAddressByStr(admin2),
+	removeArgs := &RemoveArgs{Addresses: []string{
+		admin1,
+		admin2,
 	}}
 	marshal, err := json.Marshal(removeArgs)
 	assert.Nil(t, err)
@@ -402,7 +415,7 @@ func TestGetArgsForRemove(t *testing.T) {
 	actualArgs, ok := arg.(*RemoveArgs)
 	assert.True(t, ok)
 
-	assert.Equal(t, removeArgs.Addresses[0].String(), actualArgs.Addresses[0].String())
+	assert.Equal(t, removeArgs.Addresses[0], actualArgs.Addresses[0])
 
 }
 
@@ -453,18 +466,18 @@ func TestAddAndRemoveKycService(t *testing.T) {
 
 	stateLedger.EXPECT().GetOrCreateAccount(gomock.Any()).Return(account).AnyTimes()
 
-	kycservices := []*KycService{
+	kycservices := []KycService{
 		{
-			*types.NewAddressByStr(admin1),
+			admin1,
 		},
 		{
-			*types.NewAddressByStr(admin2),
+			admin2,
 		},
 	}
 
 	testcases := []struct {
 		method ModifyType
-		data   []*KycService
+		data   []KycService
 		err    error
 	}{
 		{
@@ -480,7 +493,12 @@ func TestAddAndRemoveKycService(t *testing.T) {
 		{
 			method: RemoveKycService,
 			data:   kycservices,
-			err:    fmt.Errorf("ACCESS ERROR: remove kyc services from an empty list"),
+			err:    fmt.Errorf("access error: remove kyc services from an empty list"),
+		},
+		{
+			method: 3,
+			data:   nil,
+			err:    fmt.Errorf("access error: wrong submit type"),
 		},
 	}
 	for _, test := range testcases {
@@ -509,12 +527,12 @@ func TestGetKycServices(t *testing.T) {
 	assert.True(t, len(services) == 0)
 
 	// case 2 not nil list
-	kycservices := []*KycService{
+	kycservices := []KycService{
 		{
-			*types.NewAddressByStr(admin1),
+			admin1,
 		},
 		{
-			*types.NewAddressByStr(admin2),
+			admin2,
 		},
 	}
 	err = SetKycService(stateLedger, kycservices)
@@ -534,12 +552,12 @@ func TestSetKycService(t *testing.T) {
 	assert.Nil(t, err)
 	account := ledger.NewAccount(ld, accountCache, types.NewAddressByStr(common.KycVerifyContractAddr), ledger.NewChanger())
 	stateLedger.EXPECT().GetOrCreateAccount(gomock.Any()).Return(account).AnyTimes()
-	kycservices := []*KycService{
+	kycservices := []KycService{
 		{
-			*types.NewAddressByStr(admin1),
+			admin1,
 		},
 		{
-			*types.NewAddressByStr(admin2),
+			admin2,
 		},
 	}
 	err = SetKycService(stateLedger, kycservices)
@@ -580,29 +598,29 @@ func TestKycVerification_checkErrSubmitInfo(t *testing.T) {
 	})
 	testcases := []struct {
 		from    *types.Address
-		kycinfo *KycInfo
+		kycinfo KycInfo
 		err     error
 	}{
 		{
 			from: types.NewAddressByStr(admin1),
-			kycinfo: &KycInfo{
-				User:    *types.NewAddressByStr(admin1),
-				KycAddr: *types.NewAddressByStr(admin2),
+			kycinfo: KycInfo{
+				User:    admin1,
+				KycAddr: admin2,
 				KycFlag: 1,
-				Expires: -1,
+				Expires: time.Now().Unix() + 1000,
 			},
 			err: ErrCheckSubmitInfo,
 		},
 		{
 			from:    types.NewAddressByStr(admin1),
-			kycinfo: nil,
+			kycinfo: KycInfo{},
 			err:     ErrCheckSubmitInfo,
 		},
 		{
 			from: types.NewAddressByStr(admin1),
-			kycinfo: &KycInfo{
-				User:    *types.NewAddressByStr(admin1),
-				KycAddr: *types.NewAddressByStr(admin1),
+			kycinfo: KycInfo{
+				User:    admin1,
+				KycAddr: admin1,
 				KycFlag: 1,
 				Expires: 1,
 			},
@@ -610,13 +628,23 @@ func TestKycVerification_checkErrSubmitInfo(t *testing.T) {
 		},
 		{
 			from: types.NewAddressByStr(admin1),
-			kycinfo: &KycInfo{
-				User:    *types.NewAddressByStr(admin1),
-				KycAddr: *types.NewAddressByStr(admin1),
+			kycinfo: KycInfo{
+				User:    admin1,
+				KycAddr: admin1,
 				KycFlag: 3,
-				Expires: -1,
+				Expires: time.Now().Unix() + 1000,
 			},
-			err: nil,
+			err: ErrCheckSubmitInfo,
+		},
+		{
+			from: types.NewAddressByStr(admin1),
+			kycinfo: KycInfo{
+				User:    "admin1",
+				KycAddr: admin1,
+				KycFlag: 1,
+				Expires: time.Now().Unix() + 1000,
+			},
+			err: ErrCheckSubmitInfo,
 		},
 	}
 
@@ -645,15 +673,16 @@ func TestVerify(t *testing.T) {
 
 	// test fail to get state
 	testcase := struct {
-		needApprove *types.Address
-		expected    bool
-		err         error
+		needApproveAddr string
+		expected        bool
+		err             error
 	}{
-		needApprove: types.NewAddressByStr(admin2),
-		expected:    false,
-		err:         fmt.Errorf("ACCESS ERROR: Verify: fail by GetState"),
+		needApproveAddr: admin2,
+		expected:        false,
+		// Verify: fail by GetState
+		err: fmt.Errorf("access error"),
 	}
-	verify, err := Verify(stateLedger, testcase.needApprove)
+	verify, err := Verify(stateLedger, testcase.needApproveAddr)
 	assert.Equal(t, testcase.err, err)
 	assert.Equal(t, testcase.expected, verify)
 
@@ -661,75 +690,61 @@ func TestVerify(t *testing.T) {
 	admins := []string{admin1}
 	InitKycServicesAndKycInfos(stateLedger, admins, admins)
 	testcases := []struct {
-		needApprove *types.Address
-		submitAddr  *types.Address
-		submitArgs  *SubmitArgs
+		needApprove string
+		kycInfo     KycInfo
 		expected    bool
 		err         error
 	}{
 		{
-			needApprove: types.NewAddressByStr(admin2),
-			submitAddr:  types.NewAddressByStr(admin1),
-			submitArgs: &SubmitArgs{KycInfos: []*KycInfo{
-				{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin1),
-					KycFlag: 1,
-					Expires: -1,
-				},
-			}},
+			needApprove: admin2,
+			kycInfo: KycInfo{
+				User:    admin2,
+				KycAddr: admin1,
+				KycFlag: Verified,
+				Expires: time.Now().Unix() + 10000,
+			},
 			expected: true,
 			err:      nil,
 		},
 		{
-			needApprove: types.NewAddressByStr(admin2),
-			submitAddr:  types.NewAddressByStr(admin1),
-			submitArgs: &SubmitArgs{KycInfos: []*KycInfo{
-				{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin1),
-					KycFlag: 1,
-					Expires: time.Now().Unix() + 1000,
-				},
-			}},
+			needApprove: admin2,
+			kycInfo: KycInfo{
+				User:    admin2,
+				KycAddr: admin1,
+				KycFlag: Verified,
+				Expires: time.Now().Unix() + 1000,
+			},
 			expected: true,
 			err:      nil,
 		},
 		{
-			needApprove: types.NewAddressByStr(admin2),
-			submitAddr:  types.NewAddressByStr(admin1),
-			submitArgs: &SubmitArgs{KycInfos: []*KycInfo{
-				{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin1),
-					KycFlag: 0,
-					Expires: -1,
-				},
-			}},
+			needApprove: admin2,
+			kycInfo: KycInfo{User: admin2,
+				KycAddr: admin1,
+				KycFlag: NotVerified,
+				Expires: time.Now().Unix() + 10000,
+			},
 			expected: false,
-			err:      fmt.Errorf("ACCESS ERROR: Verify: fail by checking kyc info"),
+			// Verify: fail by checking kyc info
+			err: fmt.Errorf("access error"),
 		},
 		{
-			needApprove: types.NewAddressByStr(admin2),
-			submitAddr:  types.NewAddressByStr(admin1),
-			submitArgs: &SubmitArgs{KycInfos: []*KycInfo{
-				{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin1),
-					KycFlag: 2,
-					Expires: time.Now().Unix() + 10000,
-				},
-			}},
+			needApprove: admin2,
+			kycInfo: KycInfo{
+				User:    admin2,
+				KycAddr: admin1,
+				KycFlag: 2,
+				Expires: time.Now().Unix() + 10000,
+			},
 			expected: false,
-			err:      fmt.Errorf("ACCESS ERROR: Verify: fail by checking kyc info"),
+			// Verify: fail by checking kyc info
+			err: fmt.Errorf("access error"),
 		},
 	}
 
 	for _, test := range testcases {
-		submit := test.submitAddr.ETHAddress()
 		cm.Reset(stateLedger)
-		_, err := cm.Submit(&submit, test.submitArgs)
-		assert.Nil(t, err)
+		cm.saveKycInfo(test.kycInfo)
 		verify, err := Verify(stateLedger, test.needApprove)
 		assert.Equal(t, test.err, err)
 		assert.Equal(t, test.expected, verify)
@@ -767,21 +782,21 @@ func TestKycVerification_ErrorSubmit(t *testing.T) {
 		{
 			from: types.NewAddressByStr(admin2).ETHAddress(),
 			args: &SubmitArgs{
-				KycInfos: []*KycInfo{{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin2),
+				KycInfos: []KycInfo{{
+					User:    admin2,
+					KycAddr: admin2,
 					KycFlag: 0,
 					Expires: 0,
 				}},
 			},
-			err: fmt.Errorf("ACCESS ERROR: Submit: fail by checking kyc services"),
+			err: fmt.Errorf("access error: Submit: fail by checking kyc services"),
 		},
 		{
 			from: types.NewAddressByStr(admin1).ETHAddress(),
 			args: &SubmitArgs{
-				KycInfos: []*KycInfo{{
-					User:    *types.NewAddressByStr(admin2),
-					KycAddr: *types.NewAddressByStr(admin2),
+				KycInfos: []KycInfo{{
+					User:    admin2,
+					KycAddr: admin2,
 					KycFlag: 0,
 					Expires: 0,
 				}},
@@ -827,14 +842,14 @@ func TestKycVerification_ErrorRemove(t *testing.T) {
 		{
 			from: types.NewAddressByStr(admin2).ETHAddress(),
 			args: &RemoveArgs{
-				Addresses: []*types.Address{types.NewAddressByStr(admin1)},
+				Addresses: []string{admin1},
 			},
-			err: fmt.Errorf("ACCESS ERROR: Remove: check kyc service fail"),
+			err: fmt.Errorf("access error: Remove: check kyc service fail"),
 		},
 		{
 			from: types.NewAddressByStr(admin1).ETHAddress(),
 			args: &RemoveArgs{
-				Addresses: []*types.Address{types.NewAddressByStr(admin3)},
+				Addresses: []string{admin3},
 			},
 			err: nil,
 		},
@@ -861,10 +876,10 @@ func TestCheckInServices(t *testing.T) {
 	state := CheckInServices(account, admin1)
 	assert.Equal(t, false, state)
 
-	err = InitKycServicesAndKycInfos(stateLedger, nil, nil)
+	err = InitKycServicesAndKycInfos(stateLedger, nil, []string{admin1})
 	assert.Nil(t, err)
 	state = CheckInServices(account, admin1)
-	assert.Equal(t, false, state)
+	assert.Equal(t, true, true)
 }
 
 func TestInitKycServicesAndKycInfos(t *testing.T) {
@@ -909,14 +924,14 @@ func TestKycVerification_getErrorArgs(t *testing.T) {
 			data: &vm.Message{
 				Data: []byte{83, 44, 81, 214, 0},
 			},
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{0}, []byte{0}).Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{0}, []byte{0}).Error(),
 		},
 		{
 			method: "Remove",
 			data: &vm.Message{
 				Data: []byte{42, 198, 250, 166, 0},
 			},
-			Expected: fmt.Errorf("ACCESS ERROR: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{0}, []byte{0}).Error(),
+			Expected: fmt.Errorf("access error: ParseArgs: improperly formatted output: %q - Bytes: %+v", []byte{0}, []byte{0}).Error(),
 		},
 	}
 

--- a/internal/executor/system/common/common.go
+++ b/internal/executor/system/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	ethtype "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
 
 	"github.com/axiomesh/axiom-kit/types"
@@ -64,4 +65,9 @@ type Log struct {
 	Topics  []*types.Hash
 	Data    []byte
 	Removed bool
+}
+
+func CalculateDynamicGas(bytes []byte) uint64 {
+	gas, _ := vm.IntrinsicGas(bytes, []ethtype.AccessTuple{}, false, true, true, true)
+	return gas
 }

--- a/internal/executor/system/governance/council_manager.go
+++ b/internal/executor/system/governance/council_manager.go
@@ -37,13 +37,6 @@ const (
 
 	// MinCouncilMembersCount is min council members count
 	MinCouncilMembersCount = 4
-
-	// TODO: set used gas
-	// CouncilProposalGas is used gas for council proposal
-	CouncilProposalGas uint64 = 30000
-
-	// CouncilVoteGas is used gas for council vote
-	CouncilVoteGas uint64 = 21600
 )
 
 // CouncilExtraArgs is council proposal extra arguments
@@ -146,6 +139,10 @@ func (cm *CouncilManager) Run(msg *vm.Message) (result *vm.ExecutionResult, err 
 		return nil, errors.New("unknown proposal args")
 	}
 
+	if result != nil {
+		usedGas := common.CalculateDynamicGas(msg.Data)
+		result.UsedGas = usedGas
+	}
 	return result, err
 }
 
@@ -206,7 +203,6 @@ func (cm *CouncilManager) propose(addr ethcommon.Address, args *CouncilProposalA
 	cm.gov.RecordLog(cm.currentLog, ProposeMethod, &proposal.BaseProposal, b)
 
 	return &vm.ExecutionResult{
-		UsedGas:    CouncilProposalGas,
 		ReturnData: b,
 		Err:        err,
 	}, nil
@@ -215,7 +211,7 @@ func (cm *CouncilManager) propose(addr ethcommon.Address, args *CouncilProposalA
 // Vote a proposal, return vote status
 func (cm *CouncilManager) vote(user ethcommon.Address, voteArgs *CouncilVoteArgs) (*vm.ExecutionResult, error) {
 	cm.gov.logger.Debugf("Vote council election, addr: %s, args: %+v", user.String(), voteArgs)
-	result := &vm.ExecutionResult{UsedGas: CouncilVoteGas}
+	result := &vm.ExecutionResult{}
 
 	// check user can vote
 	isExist, _ := CheckInCouncil(cm.account, user.String())
@@ -288,22 +284,12 @@ func (cm *CouncilManager) saveProposal(proposal *CouncilProposal) ([]byte, error
 }
 
 func (cm *CouncilManager) EstimateGas(callArgs *types.CallArgs) (uint64, error) {
-	args, err := cm.gov.GetArgs(&vm.Message{Data: *callArgs.Data})
+	_, err := cm.gov.GetArgs(&vm.Message{Data: *callArgs.Data})
 	if err != nil {
 		return 0, err
 	}
 
-	var gas uint64
-	switch args.(type) {
-	case *ProposalArgs:
-		gas = CouncilProposalGas
-	case *VoteArgs:
-		gas = CouncilVoteGas
-	default:
-		return 0, errors.New("unknown proposal args")
-	}
-
-	return gas, nil
+	return common.CalculateDynamicGas(*callArgs.Data), nil
 }
 
 func (cm *CouncilManager) CheckAndUpdateState(lastHeight uint64, stateLedger ledger.StateLedger) {

--- a/internal/executor/system/governance/council_manager_test.go
+++ b/internal/executor/system/governance/council_manager_test.go
@@ -166,7 +166,30 @@ func TestRunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: CouncilProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateProposeData(t, CouncilExtraArgs{
+					Candidates: []*CouncilMember{
+						{
+							Address: admin1,
+							Weight:  1,
+							Name:    "111",
+						},
+						{
+							Address: admin2,
+							Weight:  1,
+							Name:    "222",
+						},
+						{
+							Address: admin3,
+							Weight:  1,
+							Name:    "333",
+						},
+						{
+							Address: admin4,
+							Weight:  1,
+							Name:    "444",
+						},
+					},
+				})),
 				ReturnData: generateReturnData(t, &TestCouncilProposal{
 					ID:          1,
 					Type:        CouncilElect,
@@ -228,7 +251,30 @@ func TestRunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: CouncilProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateProposeData(t, CouncilExtraArgs{
+					Candidates: []*CouncilMember{
+						{
+							Address: admin1,
+							Weight:  1,
+							Name:    "111",
+						},
+						{
+							Address: admin2,
+							Weight:  1,
+							Name:    "222",
+						},
+						{
+							Address: admin3,
+							Weight:  1,
+							Name:    "333",
+						},
+						{
+							Address: admin4,
+							Weight:  1,
+							Name:    "444",
+						},
+					},
+				})),
 			},
 			Err: ErrNotFoundCouncilMember,
 		},
@@ -348,7 +394,7 @@ func TestRunForVote(t *testing.T) {
 			Caller: admin2,
 			Data:   generateVoteData(t, cm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: CouncilVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateVoteData(t, cm.proposalID.GetID()-1, Pass)),
 				ReturnData: generateReturnData(t, &TestCouncilProposal{
 					ID:          1,
 					Type:        CouncilElect,
@@ -387,7 +433,7 @@ func TestRunForVote(t *testing.T) {
 			Caller: admin3,
 			Data:   generateVoteData(t, cm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: CouncilVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateVoteData(t, cm.proposalID.GetID()-1, Pass)),
 				ReturnData: generateReturnData(t, &TestCouncilProposal{
 					ID:          1,
 					Type:        CouncilElect,
@@ -476,7 +522,7 @@ func TestEstimateGas(t *testing.T) {
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, CouncilProposalGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(data), gas)
 
 	// test vote
 	data = hexutil.Bytes(generateVoteData(t, 1, Pass))
@@ -486,7 +532,7 @@ func TestEstimateGas(t *testing.T) {
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, CouncilVoteGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(data), gas)
 }
 
 func generateProposeData(t *testing.T, extraArgs CouncilExtraArgs) []byte {

--- a/internal/executor/system/governance/kycservice_manager.go
+++ b/internal/executor/system/governance/kycservice_manager.go
@@ -2,7 +2,6 @@ package governance
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/axiomesh/axiom-kit/types"
@@ -15,9 +14,7 @@ import (
 )
 
 const (
-	KycProposalGas uint64 = 30000
-	KycVoteGas     uint64 = 30000
-	KycProposalKey        = "KycProposal"
+	KycProposalKey = "KycProposal"
 )
 
 var _ common.SystemContract = (*KycServiceManager)(nil)
@@ -73,50 +70,50 @@ func NewKycServiceManager(cfg *common.SystemContractConfig) *KycServiceManager {
 
 func (ac *KycServiceManager) Run(msg *vm.Message) (*vm.ExecutionResult, error) {
 	defer ac.gov.SaveLog(ac.stateLedger, ac.currentLog)
-
 	// parse method and arguments from msg payload
 	args, err := ac.gov.GetArgs(msg)
 	if err != nil {
 		return nil, err
 	}
 
+	gasUse := common.CalculateDynamicGas(msg.Data)
 	switch v := args.(type) {
 	case *ProposalArgs:
 		proposalArgs, err := ac.getKycProposalArgs(v)
 		if err != nil {
 			return nil, err
 		}
-		return ac.propose(&msg.From, proposalArgs)
+		proposeRes, err := ac.propose(&msg.From, proposalArgs)
+		// gas will not be used if err
+		if proposeRes != nil {
+			proposeRes.UsedGas = gasUse
+		}
+		return proposeRes, err
 	case *VoteArgs:
-		return ac.vote(&msg.From, &KycVoteArgs{BaseVoteArgs: v.BaseVoteArgs})
+		voteRes, err := ac.vote(&msg.From, &KycVoteArgs{BaseVoteArgs: v.BaseVoteArgs})
+		// gas will not be used if err
+		if voteRes != nil {
+			voteRes.UsedGas = gasUse
+		}
+		return voteRes, err
 	default:
 		return nil, fmt.Errorf("unknown proposal args")
 	}
 }
 
 func (ac *KycServiceManager) EstimateGas(callArgs *types.CallArgs) (uint64, error) {
-	args, err := ac.gov.GetArgs(&vm.Message{Data: *callArgs.Data})
+	_, err := ac.gov.GetArgs(&vm.Message{Data: *callArgs.Data})
 	if err != nil {
 		return 0, err
 	}
-
-	var gas uint64
-	switch args.(type) {
-	case *ProposalArgs:
-		gas = KycProposalGas
-	case *VoteArgs:
-		gas = KycVoteGas
-	default:
-		return 0, errors.New("unknown proposal args")
-	}
-
+	gas := common.CalculateDynamicGas(*callArgs.Data)
 	return gas, nil
 }
 
 func (ac *KycServiceManager) CheckAndUpdateState(u uint64, stateLedger ledger.StateLedger) {}
 
 func (ac *KycServiceManager) vote(user *ethcommon.Address, voteArgs *KycVoteArgs) (*vm.ExecutionResult, error) {
-	result := &vm.ExecutionResult{UsedGas: KycVoteGas}
+	result := &vm.ExecutionResult{}
 
 	// get proposal
 	proposal, err := ac.loadKycProposal(voteArgs.ProposalId)
@@ -181,8 +178,18 @@ func (ac *KycServiceManager) voteServicesAddRemove(user *ethcommon.Address, prop
 }
 
 func (ac *KycServiceManager) propose(addr *ethcommon.Address, args *KycProposalArgs) (*vm.ExecutionResult, error) {
-	result := &vm.ExecutionResult{
-		UsedGas: KycProposalGas,
+	result := &vm.ExecutionResult{}
+
+	// check finished council proposals and kyc service proposals
+	if _, err := ac.checkFinishedProposal(); err != nil {
+		return nil, err
+	}
+
+	// check proposal services has repeated address
+	if len(lo.Uniq[string](lo.Map[access.KycService, string](args.Services, func(item access.KycService, index int) string {
+		return item.KycAddr
+	}))) != len(args.Services) {
+		return nil, fmt.Errorf("kyc services address repeated")
 	}
 
 	result.ReturnData, result.Err = ac.proposeServicesAddRemove(addr, args)
@@ -198,7 +205,7 @@ func (ac *KycServiceManager) getKycProposalArgs(args *ProposalArgs) (*KycProposa
 	}
 	serviceArgs := &access.KycServiceArgs{}
 	if err := json.Unmarshal(args.Extra, serviceArgs); err != nil {
-		return nil, fmt.Errorf("unmarshal node extra arguments error")
+		return nil, fmt.Errorf("unmarshal services extra arguments error")
 	}
 	kycArgs.KycServiceArgs = *serviceArgs
 	return kycArgs, nil
@@ -242,4 +249,34 @@ func (ac *KycServiceManager) saveKycProposal(proposal *KycProposal) ([]byte, err
 	// save proposal
 	ac.account.SetState([]byte(fmt.Sprintf("%s%d", KycProposalKey, proposal.ID)), b)
 	return b, nil
+}
+
+func (ac *KycServiceManager) checkFinishedProposal() (bool, error) {
+	if isExist, data := ac.councilAccount.Query(CouncilProposalKey); isExist {
+		for _, proposalData := range data {
+			proposal := &CouncilProposal{}
+			if err := json.Unmarshal(proposalData, proposal); err != nil {
+				return false, fmt.Errorf("check finished council proposal fail: json.Unmarshal fail")
+			}
+
+			if proposal.Status == Voting {
+				return false, fmt.Errorf("check finished council proposal fail: exist voting proposal")
+			}
+		}
+	}
+
+	if isExist, data := ac.account.Query(KycProposalKey); isExist {
+		for _, proposalData := range data {
+			proposal := &KycProposal{}
+			if err := json.Unmarshal(proposalData, proposal); err != nil {
+				return false, fmt.Errorf("check finished kyc service proposal fail: json.Unmarshal fail")
+			}
+
+			if proposal.Status == Voting {
+				return false, fmt.Errorf("check finished kyc service proposal fail: exist voting proposal")
+			}
+		}
+	}
+
+	return true, nil
 }

--- a/internal/executor/system/governance/kycservice_manager_test.go
+++ b/internal/executor/system/governance/kycservice_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/axiomesh/axiom-ledger/internal/executor/system/access"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtype "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -35,7 +36,7 @@ type TestKycServiceProposal struct {
 	PassVotes   []string
 	RejectVotes []string
 	Status      ProposalStatus
-	Services    []*access.KycService
+	Services    []access.KycService
 }
 
 func TestKycServiceManager_RunForPropose(t *testing.T) {
@@ -90,12 +91,12 @@ func TestKycServiceManager_RunForPropose(t *testing.T) {
 		{
 			Caller: KycService1,
 			Data: generateKycProposeData(t, KycServiceAdd, access.KycServiceArgs{
-				Services: []*access.KycService{
+				Services: []access.KycService{
 					{
-						KycAddr: *types.NewAddressByStr(KycService1),
+						KycAddr: KycService1,
 					},
 					{
-						KycAddr: *types.NewAddressByStr(KycService2),
+						KycAddr: KycService2,
 					},
 				},
 			}),
@@ -105,17 +106,26 @@ func TestKycServiceManager_RunForPropose(t *testing.T) {
 		{
 			Caller: admin1,
 			Data: generateKycProposeData(t, KycServiceAdd, access.KycServiceArgs{
-				Services: []*access.KycService{
+				Services: []access.KycService{
 					{
-						KycAddr: *types.NewAddressByStr(KycService1),
+						KycAddr: KycService1,
 					},
 					{
-						KycAddr: *types.NewAddressByStr(KycService2),
+						KycAddr: KycService2,
 					},
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateKycProposeData(t, KycServiceAdd, access.KycServiceArgs{
+					Services: []access.KycService{
+						{
+							KycAddr: KycService1,
+						},
+						{
+							KycAddr: KycService2,
+						},
+					},
+				})),
 				ReturnData: generateKycReturnData(t, &TestKycServiceProposal{
 					ID:          1,
 					Type:        KycServiceAdd,
@@ -124,12 +134,12 @@ func TestKycServiceManager_RunForPropose(t *testing.T) {
 					PassVotes:   []string{admin1},
 					RejectVotes: nil,
 					Status:      Voting,
-					Services: []*access.KycService{
+					Services: []access.KycService{
 						{
-							KycAddr: *types.NewAddressByStr(KycService1),
+							KycAddr: KycService1,
 						},
 						{
-							KycAddr: *types.NewAddressByStr(KycService2),
+							KycAddr: KycService2,
 						},
 					},
 				}),
@@ -140,7 +150,7 @@ func TestKycServiceManager_RunForPropose(t *testing.T) {
 			Caller: admin1,
 			Data:   []byte{0, 1, 2, 3},
 			Expected: vm.ExecutionResult{
-				UsedGas:    KycProposalGas,
+				UsedGas:    common.CalculateDynamicGas([]byte{0, 1, 2, 3}),
 				ReturnData: nil,
 				Err:        ErrMethodName,
 			},
@@ -231,12 +241,12 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 			BlockNumber:  1000,
 		},
 		KycServiceArgs: access.KycServiceArgs{
-			Services: []*access.KycService{
+			Services: []access.KycService{
 				{
-					KycAddr: *types.NewAddressByStr(KycService1),
+					KycAddr: KycService1,
 				},
 				{
-					KycAddr: *types.NewAddressByStr(KycService2),
+					KycAddr: KycService2,
 				},
 			},
 		},
@@ -252,7 +262,7 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 			Caller: admin2,
 			Data:   generateKycVoteData(t, ks.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateKycVoteData(t, ks.proposalID.GetID()-1, Pass)),
 				ReturnData: generateKycReturnData(t, &TestKycServiceProposal{
 					ID:          1,
 					Type:        KycServiceAdd,
@@ -261,12 +271,12 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 					PassVotes:   []string{admin1, admin2},
 					RejectVotes: nil,
 					Status:      Voting,
-					Services: []*access.KycService{
+					Services: []access.KycService{
 						{
-							KycAddr: *types.NewAddressByStr(KycService1),
+							KycAddr: KycService1,
 						},
 						{
-							KycAddr: *types.NewAddressByStr(KycService2),
+							KycAddr: KycService2,
 						},
 					},
 				}),
@@ -277,7 +287,7 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 			Caller: admin3,
 			Data:   generateKycVoteData(t, ks.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateKycVoteData(t, ks.proposalID.GetID()-1, Pass)),
 				ReturnData: generateKycReturnData(t, &TestKycServiceProposal{
 					ID:          1,
 					Type:        KycServiceAdd,
@@ -286,12 +296,12 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 					PassVotes:   []string{admin1, admin2, admin3},
 					RejectVotes: nil,
 					Status:      Approved,
-					Services: []*access.KycService{
+					Services: []access.KycService{
 						{
-							KycAddr: *types.NewAddressByStr(KycService1),
+							KycAddr: KycService1,
 						},
 						{
-							KycAddr: *types.NewAddressByStr(KycService2),
+							KycAddr: KycService2,
 						},
 					},
 				}),
@@ -302,7 +312,7 @@ func TestKycServiceManager_RunForVoteAdd(t *testing.T) {
 			Caller: "0xfff0000000000000000000000000000000000000",
 			Data:   generateKycVoteData(t, ks.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateKycVoteData(t, ks.proposalID.GetID()-1, Pass)),
 				Err:     ErrNotFoundCouncilMember,
 			},
 			Err: ErrNotFoundCouncilMember,
@@ -389,12 +399,12 @@ func TestKycServiceManager_RunForVoteRemove(t *testing.T) {
 			BlockNumber:  1000,
 		},
 		KycServiceArgs: access.KycServiceArgs{
-			Services: []*access.KycService{
+			Services: []access.KycService{
 				{
-					KycAddr: *types.NewAddressByStr(KycService1),
+					KycAddr: KycService1,
 				},
 				{
-					KycAddr: *types.NewAddressByStr(KycService2),
+					KycAddr: KycService2,
 				},
 			},
 		},
@@ -410,7 +420,7 @@ func TestKycServiceManager_RunForVoteRemove(t *testing.T) {
 			Caller: admin2,
 			Data:   generateKycVoteData(t, ks.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateKycVoteData(t, ks.proposalID.GetID()-1, Pass)),
 				ReturnData: generateKycReturnData(t, &TestKycServiceProposal{
 					ID:          1,
 					Type:        KycServiceRemove,
@@ -419,12 +429,12 @@ func TestKycServiceManager_RunForVoteRemove(t *testing.T) {
 					PassVotes:   []string{admin1, admin2},
 					RejectVotes: nil,
 					Status:      Voting,
-					Services: []*access.KycService{
+					Services: []access.KycService{
 						{
-							KycAddr: *types.NewAddressByStr(KycService1),
+							KycAddr: KycService1,
 						},
 						{
-							KycAddr: *types.NewAddressByStr(KycService2),
+							KycAddr: KycService2,
 						},
 					},
 				}),
@@ -435,7 +445,7 @@ func TestKycServiceManager_RunForVoteRemove(t *testing.T) {
 			Caller: admin3,
 			Data:   generateKycVoteData(t, ks.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: KycVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateKycVoteData(t, ks.proposalID.GetID()-1, Pass)),
 				ReturnData: generateKycReturnData(t, &TestKycServiceProposal{
 					ID:          1,
 					Type:        KycServiceRemove,
@@ -444,17 +454,17 @@ func TestKycServiceManager_RunForVoteRemove(t *testing.T) {
 					PassVotes:   []string{admin1, admin2, admin3},
 					RejectVotes: nil,
 					Status:      Approved,
-					Services: []*access.KycService{
+					Services: []access.KycService{
 						{
-							KycAddr: *types.NewAddressByStr(KycService1),
+							KycAddr: KycService1,
 						},
 						{
-							KycAddr: *types.NewAddressByStr(KycService2),
+							KycAddr: KycService2,
 						},
 					},
 				}),
 			},
-			Err: fmt.Errorf("ACCESS ERROR: remove kyc services from an empty list"),
+			Err: fmt.Errorf("access error: remove kyc services from an empty list"),
 		},
 	}
 
@@ -491,12 +501,12 @@ func TestKycServiceManager_EstimateGas(t *testing.T) {
 	from := types.NewAddressByStr(admin1).ETHAddress()
 	to := types.NewAddressByStr(common.KycServiceContractAddr).ETHAddress()
 	data := hexutil.Bytes(generateKycProposeData(t, KycServiceAdd, access.KycServiceArgs{
-		Services: []*access.KycService{
+		Services: []access.KycService{
 			{
-				KycAddr: *types.NewAddressByStr(KycService1),
+				KycAddr: KycService1,
 			},
 			{
-				KycAddr: *types.NewAddressByStr(KycService2),
+				KycAddr: KycService2,
 			},
 		},
 	}))
@@ -507,7 +517,8 @@ func TestKycServiceManager_EstimateGas(t *testing.T) {
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, KycProposalGas, gas)
+	intrinsicGas, _ := vm.IntrinsicGas(data, []ethtype.AccessTuple{}, false, true, true, true)
+	assert.Equal(t, intrinsicGas, gas)
 
 	// test vote
 	data = hexutil.Bytes(generateKycVoteData(t, 1, Pass))
@@ -517,7 +528,8 @@ func TestKycServiceManager_EstimateGas(t *testing.T) {
 		Data: &data,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, KycVoteGas, gas)
+	intrinsicGas, _ = vm.IntrinsicGas(data, []ethtype.AccessTuple{}, false, true, true, true)
+	assert.Equal(t, intrinsicGas, gas)
 
 	// test error args
 	data = hexutil.Bytes([]byte{0, 1, 2, 3})
@@ -608,4 +620,82 @@ func TestKycServiceManager_loadKycProposal(t *testing.T) {
 	ks.Reset(stateLedger)
 	_, err = ks.loadKycProposal(1)
 	assert.Equal(t, fmt.Errorf("node proposal not found for the id"), err)
+}
+
+func TestKycServiceManager_checkFinishedProposal_kycProposal(t *testing.T) {
+	ks := NewKycServiceManager(&common.SystemContractConfig{
+		Logger: logrus.New(),
+	})
+
+	mockCtl := gomock.NewController(t)
+	stateLedger := mock_ledger.NewMockStateLedger(mockCtl)
+
+	accountCache, err := ledger.NewAccountCache()
+	assert.Nil(t, err)
+	repoRoot := t.TempDir()
+	ld, err := leveldb.New(filepath.Join(repoRoot, "kycservice_manager"), nil)
+	assert.Nil(t, err)
+	account := ledger.NewAccount(ld, accountCache, types.NewAddressByStr(common.KycServiceContractAddr), ledger.NewChanger())
+
+	stateLedger.EXPECT().GetOrCreateAccount(gomock.Any()).Return(account).AnyTimes()
+	ks.Reset(stateLedger)
+
+	kycProposal := &KycProposal{
+		BaseProposal: BaseProposal{
+			ID:          1,
+			Type:        0,
+			Strategy:    0,
+			Proposer:    "",
+			Title:       "",
+			Desc:        "",
+			BlockNumber: 0,
+			TotalVotes:  0,
+			PassVotes:   nil,
+			RejectVotes: nil,
+			Status:      Voting,
+		},
+	}
+	b, _ := json.Marshal(kycProposal)
+	ks.account.SetState([]byte(fmt.Sprintf("%s%d", KycProposalKey, kycProposal.ID)), b)
+	_, err = ks.checkFinishedProposal()
+	assert.Equal(t, fmt.Errorf("check finished kyc service proposal fail: exist voting proposal"), err)
+}
+
+func TestKycServiceManager_checkFinishedProposal_councilProposal(t *testing.T) {
+	ks := NewKycServiceManager(&common.SystemContractConfig{
+		Logger: logrus.New(),
+	})
+
+	mockCtl := gomock.NewController(t)
+	stateLedger := mock_ledger.NewMockStateLedger(mockCtl)
+
+	accountCache, err := ledger.NewAccountCache()
+	assert.Nil(t, err)
+	repoRoot := t.TempDir()
+	ld, err := leveldb.New(filepath.Join(repoRoot, "kycservice_manager"), nil)
+	assert.Nil(t, err)
+	account := ledger.NewAccount(ld, accountCache, types.NewAddressByStr(common.KycServiceContractAddr), ledger.NewChanger())
+
+	stateLedger.EXPECT().GetOrCreateAccount(gomock.Any()).Return(account).AnyTimes()
+
+	proposal := &CouncilProposal{
+		BaseProposal: BaseProposal{
+			ID:          1,
+			Type:        0,
+			Strategy:    0,
+			Proposer:    "",
+			Title:       "",
+			Desc:        "",
+			BlockNumber: 0,
+			TotalVotes:  0,
+			PassVotes:   nil,
+			RejectVotes: nil,
+			Status:      Voting,
+		},
+	}
+	b, _ := json.Marshal(proposal)
+	ks.Reset(stateLedger)
+	ks.councilAccount.SetState([]byte(fmt.Sprintf("%s%d", CouncilProposalKey, proposal.ID)), b)
+	_, err = ks.checkFinishedProposal()
+	assert.Equal(t, fmt.Errorf("check finished council proposal fail: exist voting proposal"), err)
 }

--- a/internal/executor/system/governance/node_manager_test.go
+++ b/internal/executor/system/governance/node_manager_test.go
@@ -83,7 +83,13 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeAddProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 			},
 			Err: nil,
 		},
@@ -97,6 +103,13 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
+				UsedGas: common.CalculateDynamicGas(generateNodeAddProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 				Err: ErrNotFoundCouncilMember,
 			},
 			Err: nil,
@@ -114,6 +127,16 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
+				UsedGas: common.CalculateDynamicGas(generateNodeAddProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 				Err: ErrRepeatedNodeID,
 			},
 			Err: nil,
@@ -128,7 +151,13 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeRemoveProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 			},
 			Err: nil,
 		},
@@ -142,6 +171,13 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
+				UsedGas: common.CalculateDynamicGas(generateNodeRemoveProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 				Err: ErrNotFoundCouncilMember,
 			},
 			Err: nil,
@@ -159,6 +195,16 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
+				UsedGas: common.CalculateDynamicGas(generateNodeRemoveProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 				Err: ErrRepeatedNodeID,
 			},
 			Err: nil,
@@ -175,7 +221,7 @@ func TestNodeManager_RunForPropose(t *testing.T) {
 
 		assert.Equal(t, test.Err, err)
 		if res != nil {
-			assert.Equal(t, uint64(NodeManagementProposalGas), res.UsedGas)
+			assert.Equal(t, test.Expected.UsedGas, res.UsedGas)
 			assert.Equal(t, test.Expected.Err, res.Err)
 		}
 	}
@@ -245,7 +291,13 @@ func TestNodeManager_RunForNodeUpgradePropose(t *testing.T) {
 				},
 			}),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementProposalGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeUpgradeProposeData(t, NodeExtraArgs{
+					Nodes: []*NodeMember{
+						{
+							NodeId: "16Uiu2HAmJ38LwfY6pfgDWNvk3ypjcpEMSePNTE6Ma2NCLqjbZJSF",
+						},
+					},
+				})),
 			},
 			Err: nil,
 		},
@@ -261,7 +313,7 @@ func TestNodeManager_RunForNodeUpgradePropose(t *testing.T) {
 
 		assert.Equal(t, test.Err, err)
 		if res != nil {
-			assert.Equal(t, uint64(NodeManagementProposalGas), res.UsedGas)
+			assert.Equal(t, test.Expected.UsedGas, res.UsedGas)
 			assert.Equal(t, test.Expected.Err, res.Err)
 		}
 	}
@@ -388,7 +440,7 @@ func TestNodeManager_RunForAddVote(t *testing.T) {
 			Caller: admin1,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrUseHasVoted,
 			},
 			Err: nil,
@@ -397,7 +449,7 @@ func TestNodeManager_RunForAddVote(t *testing.T) {
 			Caller: admin2,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 			},
 			Err: nil,
 		},
@@ -405,7 +457,7 @@ func TestNodeManager_RunForAddVote(t *testing.T) {
 			Caller: admin2,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrUseHasVoted,
 			},
 			Err: nil,
@@ -414,7 +466,7 @@ func TestNodeManager_RunForAddVote(t *testing.T) {
 			Caller: "0x1000000000000000000000000000000000000000",
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrNotFoundCouncilMember,
 			},
 			Err: nil,
@@ -511,7 +563,7 @@ func TestNodeManager_RunForRemoveVote(t *testing.T) {
 			Caller: admin1,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 			},
 			Err: nil,
 		},
@@ -519,7 +571,7 @@ func TestNodeManager_RunForRemoveVote(t *testing.T) {
 			Caller: admin1,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrUseHasVoted,
 			},
 			Err: nil,
@@ -528,7 +580,7 @@ func TestNodeManager_RunForRemoveVote(t *testing.T) {
 			Caller: "0x1000000000000000000000000000000000000000",
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrNotFoundCouncilMember,
 			},
 			Err: nil,
@@ -624,7 +676,7 @@ func TestNodeManager_RunForUpgradeVote(t *testing.T) {
 			Caller: admin1,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 			},
 			Err: nil,
 		},
@@ -632,7 +684,7 @@ func TestNodeManager_RunForUpgradeVote(t *testing.T) {
 			Caller: admin1,
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrUseHasVoted,
 			},
 			Err: nil,
@@ -641,7 +693,7 @@ func TestNodeManager_RunForUpgradeVote(t *testing.T) {
 			Caller: "0x1000000000000000000000000000000000000000",
 			Data:   generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass),
 			Expected: vm.ExecutionResult{
-				UsedGas: NodeManagementVoteGas,
+				UsedGas: common.CalculateDynamicGas(generateNodeVoteData(t, nm.proposalID.GetID()-1, Pass)),
 				Err:     ErrNotFoundCouncilMember,
 			},
 			Err: nil,
@@ -686,7 +738,7 @@ func TestNodeManager_EstimateGas(t *testing.T) {
 		Data: &dataBytes,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, NodeManagementProposalGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(dataBytes), gas)
 
 	// test vote
 	data, err = gabi.Pack(VoteMethod, uint64(1), uint8(Pass), []byte(""))
@@ -698,7 +750,7 @@ func TestNodeManager_EstimateGas(t *testing.T) {
 		Data: &dataBytes,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, NodeManagementVoteGas, gas)
+	assert.Equal(t, common.CalculateDynamicGas(dataBytes), gas)
 }
 
 func generateNodeAddProposeData(t *testing.T, extraArgs NodeExtraArgs) []byte {
@@ -767,7 +819,7 @@ func runVoteMethod(nm *NodeManager, msg *vm.Message) (*vm.ExecutionResult, error
 		return nil, nil
 	}
 
-	result := &vm.ExecutionResult{UsedGas: NodeManagementVoteGas}
+	result := &vm.ExecutionResult{UsedGas: common.CalculateDynamicGas(msg.Data)}
 
 	// get proposal
 	proposal, err := nm.loadNodeProposal(voteArgs.ProposalId)

--- a/internal/ledger/account.go
+++ b/internal/ledger/account.go
@@ -310,7 +310,7 @@ func (o *SimpleAccount) AddBalance(amount *big.Int) {
 	o.SetBalance(new(big.Int).Add(o.GetBalance(), amount))
 }
 
-// Query Query the value using key
+// Query the value using key
 func (o *SimpleAccount) Query(prefix string) (bool, [][]byte) {
 	var ret [][]byte
 	stored := make(map[string][]byte)


### PR DESCRIPTION
1. Governance module dynamic gas fee.
2. The KYC service provider proposal needs to wait for council elections and other service provider proposals.
3. Service providers have added verification when submitting user KYC information. 