### PR TITLE
fix: command of config generate can produce genesis.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ GREEN=\033[0;32m
 BLUE=\033[0;34m
 NC=\033[0m
 
+GOARCH := $(or $(GOARCH),$(shell go env GOARCH))
+GOOS := $(or $(GOOS),$(shell go env GOOS))
+
 help: Makefile
 	@printf "${BLUE}Choose a command run:${NC}\n"
 	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/    /'

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -67,6 +67,9 @@ func (r *Repo) Flush() error {
 	if err := writeConfigWithEnv(path.Join(r.RepoRoot, consensusCfgFileName), r.ConsensusConfig); err != nil {
 		return errors.Wrap(err, "failed to write consensus config")
 	}
+	if err := writeConfigWithEnv(path.Join(r.RepoRoot, genesisCfgFileName), r.GenesisConfig); err != nil {
+		return errors.Wrap(err, "failed to write genesis config")
+	}
 	if err := WriteKey(path.Join(r.RepoRoot, p2pKeyFileName), r.P2PKey); err != nil {
 		return errors.Wrap(err, "failed to write node key")
 	}


### PR DESCRIPTION
1. command “ config generate ” can produce genesis.toml
2. the naming rule is modified when using command “make package version=xx”