### PR TITLE
fix: insert checkpoint set when data syncer lack too many blocks

### DIFF
--- a/internal/consensus/rbft/data_syncer/heap.go
+++ b/internal/consensus/rbft/data_syncer/heap.go
@@ -97,13 +97,15 @@ func (q *checkpointStore) prune(height uint64) (pruned []string) {
 	return
 }
 
-func (q *checkpointStore) insert(checkpoint *consensus.SignedCheckpoint) int {
+func (q *checkpointStore) insert(checkpoint *consensus.SignedCheckpoint, stateUpdate bool) int {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	// omit older checkpoints and out of range checkpoints
-	if checkpoint.Height() <= q.lastPersistedHeight || checkpoint.Height() >= q.lastPersistedHeight+q.size {
-		return 0
+	if !stateUpdate {
+		// omit older checkpoints and out of range checkpoints
+		if checkpoint.Height() <= q.lastPersistedHeight || checkpoint.Height() >= q.lastPersistedHeight+q.size {
+			return 0
+		}
 	}
 
 	item, ok := q.items[checkpoint.Height()]

--- a/internal/consensus/rbft/data_syncer/node.go
+++ b/internal/consensus/rbft/data_syncer/node.go
@@ -1096,7 +1096,7 @@ func (n *Node[T, Constraint]) handleSignedCheckpoint(sckpt *consensus.SignedChec
 	}
 
 	// 2. update checkpoint cache
-	recvNum := n.checkpointCache.insert(sckpt)
+	recvNum := n.checkpointCache.insert(sckpt, false)
 	// if reach quorum, notify node to handle quorum checkpoint
 	if n.reachQuorum(recvNum) {
 		n.logger.Debugf("checkpoint reach quorum, height: %d", sckpt.Height())
@@ -1272,7 +1272,7 @@ func (n *Node[T, Constraint]) updateHighStateTarget(target *rbfttypes.MetaState,
 		epochChanges:  epochChanges,
 	}
 	for _, checkpoint := range checkpointSet {
-		n.checkpointCache.insert(checkpoint)
+		n.checkpointCache.insert(checkpoint, true)
 	}
 }
 

--- a/internal/consensus/rbft/data_syncer/node_test.go
+++ b/internal/consensus/rbft/data_syncer/node_test.go
@@ -777,7 +777,7 @@ func TestNode_GetLowWatermark(t *testing.T) {
 	assert.Nil(t, err)
 
 	block := testutil.ConstructBlock("block", uint64(12))
-	node.checkpointCache.insert(generateSignedCheckpoint(t, node.chainState.SelfNodeInfo.ID, block.Height(), block.Hash().String(), "batchDigest"))
+	node.checkpointCache.insert(generateSignedCheckpoint(t, node.chainState.SelfNodeInfo.ID, block.Height(), block.Hash().String(), "batchDigest"), false)
 	node.highStateTarget = &stateUpdateTarget{
 		metaState: &rbfttypes.MetaState{
 			Height: block.Height(),

--- a/internal/sync/handle_test.go
+++ b/internal/sync/handle_test.go
@@ -24,6 +24,7 @@ const (
 )
 
 func TestHandleState(t *testing.T) {
+	t.Logf("Test handle state")
 	localId := 0
 	remoteId := 1
 

--- a/internal/sync/util_test.go
+++ b/internal/sync/util_test.go
@@ -41,7 +41,7 @@ const (
 	latencyTypeSendState
 )
 
-const waitCaseTimeout = 10 * time.Second
+const waitCaseTimeout = 5 * time.Second
 
 const (
 	epochPrefix = "epoch." + rbft.EpochStatePrefix


### PR DESCRIPTION
refactor: unit tests in sync part must run serially.

