### PR TITLE
fix: the memory leak caused by BatchSize

### DIFF
--- a/internal/sync/requester.go
+++ b/internal/sync/requester.go
@@ -22,6 +22,7 @@ type requester struct {
 
 	commitDataRequestPipe network.Pipe
 	commitData            common.CommitData
+	inRetryStatus         bool
 
 	ctx context.Context
 }
@@ -36,6 +37,7 @@ func newRequester(mode common.SyncMode, ctx context.Context, peerID string, heig
 		retryCh:               make(chan string, 1),
 		gotCommitDataCh:       make(chan struct{}, 1),
 		commitDataRequestPipe: pipe,
+		inRetryStatus:         false,
 		ctx:                   ctx,
 	}
 }
@@ -50,6 +52,7 @@ func (r *requester) requestRoutine(requestRetryTimeout time.Duration) {
 OUTER_LOOP:
 	for {
 		r.gotBlock = false
+		r.inRetryStatus = false
 		ticker := time.NewTicker(requestRetryTimeout)
 		// Send request and wait
 
@@ -87,12 +90,13 @@ OUTER_LOOP:
 				r.peerID = newPeer
 				continue OUTER_LOOP
 			case <-ticker.C:
-				if r.gotBlock {
+				// ensure last retry signal has been processed
+				if r.gotBlock || r.inRetryStatus {
 					continue WAIT_LOOP
 				}
 				// Timeout
 				r.postInvalidMsg(&common.InvalidMsg{NodeID: r.peerID, Height: r.blockHeight, Typ: common.SyncMsgType_TimeoutBlock})
-
+				r.inRetryStatus = true
 			case <-r.gotCommitDataCh:
 				// We got a commitData!
 				// Continue the for-loop and wait til Quit.


### PR DESCRIPTION
fix: the deadlock issue due to multiple timeout messages in requester

fix: ignore sync epoch when epoch height is not bigger than lastCommittedHeight